### PR TITLE
Fixed bug when tokenizing longer-than-one-char unknown graphemes.

### DIFF
--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -327,9 +327,13 @@ class Tokenizer(object):
 
             # case where the parsing fails
             if not parse:
-                # replace characters in string but not in orthography profile with <?>
-                parse = " " + self.find_missing_characters(
-                    self.characters(word), errors=errors)
+                # see rationale at https://github.com/cldf/segments/issues/27
+                graphemes = sorted(self.op.graphemes, key=len, reverse=True)
+                graphemes = [re.escape(gr) for gr in graphemes]
+                rule = '|'.join(graphemes + ['.'])
+                tok = [gr if gr in graphemes else '�' for gr in re.findall(rule, word)]
+                parse = '# %s #' % ' '.join(tok)
+
             parses.append(parse)
 
         # remove the outer word boundaries


### PR DESCRIPTION
This should solve https://github.com/cldf/segments/issues/27

```
In [1]: from segments import Profile, Tokenizer

In [2]: prf = Profile({'Grapheme':'t', 'mapping':'t'}, {'Grapheme':'o', 'mapping':'o'}, {'Graphem
   ...: e':'o:', 'mapping':'o:'})

In [3]: t = Tokenizer(profile=prf)

In [4]: t('tot')
Out[4]: 't o t'

In [5]: t('to:t')
Out[5]: 't o: t'

In [6]: t('to:t=')
Out[6]: 't o: t �'
```

Graphemes are `re.escape`d so no funny stuff should happen.