### PR TITLE
Fix confusing column labels in profile __unicode__ result

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ API
 'a b c d'
 >>> prf = Profile({'Grapheme': 'ab', 'mapping': 'x'}, {'Grapheme': 'cd', 'mapping': 'y'})
 >>> print(prf)
-mapping	Grapheme
+Grapheme	mapping
 ab	x
 cd	y
 >>> t = Tokenizer(profile=prf)

--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -77,7 +77,8 @@ class Profile(UnicodeMixin):
         return cls.from_text(' '.join(readlines(fname)), mapping=mapping)
 
     def __unicode__(self):
-        rows = [self.column_labels]
+        rows = [[GRAPHEME_COL] + ['%s' % col for col in self.column_labels
+                                  if col != GRAPHEME_COL]]
         for grapheme in self.graphemes:
             rows.append(
                 [grapheme] +


### PR DESCRIPTION
The README gave different column header than expected from the line above and below. I thought this might be a typo, but my installation said it was the implemented behaviour.

Looking at the implementation of the `Profile.__unicode__` method indicated that data columns are resorted, but the header columns are not. This fixes that problem.