### PR TITLE
Removes unused logging import and basicConfig.

### DIFF
--- a/src/segments/__main__.py
+++ b/src/segments/__main__.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from pathlib import Path
 
@@ -40,6 +41,7 @@ def profile(args):
 
 
 def main():  # pragma: no cover
+    logging.basicConfig()
     parser = ArgumentParser('segments')
     parser.add_argument("--encoding", help='input encoding', default="utf8")
     parser.add_argument("--profile", help='path to an orthography profile', default=None)

--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -3,7 +3,6 @@ Tokenizer of Unicode characters, grapheme clusters and tailored grapheme cluster
 (of orthographies) given an orthography profile.
 """
 import unicodedata
-import logging
 
 import regex
 from csvw.dsv import reader
@@ -12,8 +11,6 @@ from clldutils.path import readlines
 from segments.util import nfd, grapheme_pattern
 from segments import errors
 from segments.profile import Profile
-
-logging.basicConfig()
 
 
 class Rules(object):


### PR DESCRIPTION
`Tokenizer` calls `basicConfig` at module scope, meaning that users who
import `Tokenizer` without having set their own logging first lose the
ability to control log level (see #47).

Closes #47.