### PR TITLE
Averts IndexError on strings that are only diacritics

### DIFF
--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -301,7 +301,7 @@ class Tokenizer(object):
         for grapheme in reversed(graphemes):
             count -= 1
             if len(grapheme) == 1 and unicodedata.category(grapheme) == "Lm" \
-                    and not ord(grapheme) in [712, 716]:
+                    and not ord(grapheme) in [712, 716] and result:
                 temp = grapheme + temp
                 # hack for the cases where a space modifier is the first character in the
                 # string

--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -301,7 +301,7 @@ class Tokenizer(object):
         for grapheme in reversed(graphemes):
             count -= 1
             if len(grapheme) == 1 and unicodedata.category(grapheme) == "Lm" \
-                    and not ord(grapheme) in [712, 716] and result:
+                    and not ord(grapheme) in [712, 716] and len(graphemes) > 1:
                 temp = grapheme + temp
                 # hack for the cases where a space modifier is the first character in the
                 # string

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -30,6 +30,7 @@ def test_jipa(lang, testdata):
 
 def test_single_combining_character():
     assert Tokenizer()("ˈ", ipa=True) == "ˈ"
+    assert Tokenizer()("ʲ", ipa=True) == "ʲ"
 
 
 def test_characters():


### PR DESCRIPTION
Similar to #46:
```
import segments
segments.Tokenizer()("ʲ", ipa=True)
```
Will throw an IndexError. This change will skip trying to combine `"ʲ"` with an empty `result` list by checking if `graphemes` is longer than one character.