### PR TITLE
Vietnamese tone contour grouping

### DIFF
--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -301,7 +301,7 @@ class Tokenizer(object):
         for grapheme in reversed(graphemes):
             count -= 1
             if len(grapheme) == 1 and unicodedata.category(grapheme) == "Lm" \
-                    and not ord(grapheme) in [712, 716] and len(graphemes) > 1:
+                    and not ord(grapheme) in [704, 712, 716] and len(graphemes) > 1:
                 temp = grapheme + temp
                 # hack for the cases where a space modifier is the first character in the
                 # string
@@ -309,7 +309,7 @@ class Tokenizer(object):
                     result[-1] = temp + result[-1]
                 continue  # pragma: no cover
             # catch and repair stress marks
-            if len(grapheme) == 1 and (ord(grapheme) in [712, 716]) and result:
+            if len(grapheme) == 1 and (ord(grapheme) in [704, 712, 716]) and result:
                 # If result == [], there's nothing to combine with ...
                 result[-1] = grapheme + result[-1]
                 temp = ""
@@ -322,7 +322,7 @@ class Tokenizer(object):
                     temp = ""
                     continue
                 else:
-                    if unicodedata.category(result[-1][0]) == "Sk":
+                    if unicodedata.category(result[-1][0]) == "Sk" or ord(result[-1][0]) == 704:
                         result[-1] = grapheme + result[-1]
                         temp = ""
                         continue

--- a/src/segments/tokenizer.py
+++ b/src/segments/tokenizer.py
@@ -301,7 +301,7 @@ class Tokenizer(object):
         for grapheme in reversed(graphemes):
             count -= 1
             if len(grapheme) == 1 and unicodedata.category(grapheme) == "Lm" \
-                    and not ord(grapheme) in [704, 712, 716] and len(graphemes) > 1:
+                    and not ord(grapheme) in [712, 716] and len(graphemes) > 1:
                 temp = grapheme + temp
                 # hack for the cases where a space modifier is the first character in the
                 # string
@@ -309,7 +309,7 @@ class Tokenizer(object):
                     result[-1] = temp + result[-1]
                 continue  # pragma: no cover
             # catch and repair stress marks
-            if len(grapheme) == 1 and (ord(grapheme) in [704, 712, 716]) and result:
+            if len(grapheme) == 1 and (ord(grapheme) in [712, 716]) and result:
                 # If result == [], there's nothing to combine with ...
                 result[-1] = grapheme + result[-1]
                 temp = ""
@@ -322,8 +322,8 @@ class Tokenizer(object):
                     temp = ""
                     continue
                 else:
-                    if unicodedata.category(result[-1][0]) == "Sk" or ord(result[-1][0]) == 704:
-                        result[-1] = grapheme + result[-1]
+                    if unicodedata.category(result[-1][0]) == "Sk":
+                        result[-1] = grapheme + temp + result[-1]
                         temp = ""
                         continue
 


### PR DESCRIPTION
The tokenizer currently drops a glottalization diacritic (`ˀ`) in instances like the following:
```
import segments
   
segments.Tokenizer()("ʔɓaːn˧˩ ŋaː˦ˀ˥", ipa=True))
# Returns: ʔ ɓ aː n ˧˩ # ŋ aː ˦˥
```
(`˦ˀ˥` is used to mark a contour tone in Vietnamese Wiktionary transcriptions.)

This PR changes this behavior such that the output of the `Tokenizer` call above is `ʔ ɓ aː n ˧˩ # ŋ aː ˦ˀ˥`. All the tests still pass and as far as I can tell this change does not lead to any unwanted tokenization side-effects, but if anyone has alternative solutions to this problem feel free to let me know.
